### PR TITLE
replace function get_avatar_url

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -196,6 +196,8 @@ class Discourse {
         // Current user info
         global $current_user;
         get_currentuserinfo();
+        $current_user_id = get_current_user_id();
+        $avatar = get_avatar_url($current_user_id);
 
         // Map information
         $params = array(
@@ -205,7 +207,7 @@ class Discourse {
           'email' => $current_user->user_email,
           'about_me' => $current_user->description,
           'external_id' => $current_user->ID,
-          'avatar_url' => self::get_avatar_url($current_user->ID)
+          'avatar_url' => $avatar
         );
 
         // Build login string
@@ -216,12 +218,6 @@ class Discourse {
         exit;
       }
     }
-  }
-
-  function get_avatar_url( $user_id ) {
-    $avatar = get_avatar( $user_id );
-    if( preg_match( "/src=['\"](.*?)['\"]/i", $avatar, $matches ) )
-      return utf8_uri_encode( $matches[1] );
   }
 
   static function convert_relative_img_src_to_absolute($url, $content) {


### PR DESCRIPTION
Since WordPress version 4.2 it now includes its own get_avatar_url function.  Removing custom function and rewriting to use the WordPress function.